### PR TITLE
fix: Tag not showing up in URL fields

### DIFF
--- a/Tags/ACFGroupTag.php
+++ b/Tags/ACFGroupTag.php
@@ -82,6 +82,7 @@ class ACFGroupTag extends \Elementor\Core\DynamicTags\Tag
         return [
             Module::TEXT_CATEGORY,
             Module::POST_META_CATEGORY,
+            Module::URL_CATEGORY,
         ];
     }
 


### PR DESCRIPTION
The group tag for URLs will not show up unless the additional Module::URL_CATEGORY category if specified.