### PR TITLE
Fix ACFURLTag.php to pull actual field value

### DIFF
--- a/Tags/ACFURLTag.php
+++ b/Tags/ACFURLTag.php
@@ -151,6 +151,15 @@ class ACFURLTag extends \Elementor\Core\DynamicTags\Data_Tag
 	{
 		list($field, $meta_key) = Module::get_tag_value_field($this);
 
+		/**
+		 * ACF is returning default field value in $field['value']
+		 * If a value actually has been set for this group field, use it instead of the default value.
+		 */
+		$value = get_field($meta_key);
+		if ($value !== null) {
+			$field['value'] = $value;
+		}
+
 		if ($field) {
 			$value = $field['value'];
 

--- a/elementor-extension-acf-group-tag.php
+++ b/elementor-extension-acf-group-tag.php
@@ -5,6 +5,7 @@
  * Description: Unlock group acf fields in dynamic tags in elementor.
  * Author URI: https://github.com/umairahmed17
  * Author: Umair Ahmed
+ * Version: 0.1
  */
 
 /**


### PR DESCRIPTION
For fields inside of groups, Elementor never returns the value when get_field_object() is run. (Perhaps this is why they created get_sub_field_object()). And get_field_object() is what Elementor is currently using to power Module::get_tag_value_field()  Therefore, $field['value'] will only contain the default field value if any value at all. This pull request fixes your ACF URL Tag field to actually load in the field value.